### PR TITLE
Fix for importing and exporting matrix field settings

### DIFF
--- a/services/ArtVandelay_FieldsService.php
+++ b/services/ArtVandelay_FieldsService.php
@@ -40,14 +40,7 @@ class ArtVandelay_FieldsService extends BaseApplicationComponent
 
 			foreach ($group->getFields() as $field)
 			{
-				$fieldDefs[$field->handle] = array(
-					'name'         => $field->name,
-					'context'      => $field->context,
-					'instructions' => $field->instructions,
-					'translatable' => $field->translatable,
-					'type'         => $field->type,
-					'settings'     => $field->settings
-				);
+				$fieldDefs[$field->handle] = $this->getFieldDefinition($field);
 
 				if ($field->type == 'Matrix')
 				{
@@ -60,12 +53,7 @@ class ArtVandelay_FieldsService extends BaseApplicationComponent
 
 						foreach ($blockType->getFields() as $blockTypeField)
 						{
-							$blockTypeFieldDefs[$blockTypeField->handle] = array(
-								'name'         => $blockTypeField->name,
-								'required'     => $blockTypeField->required,
-								'translatable' => $blockTypeField->translatable,
-								'type'         => $blockTypeField->type
-							);
+							$blockTypeFieldDefs[$blockTypeField->handle] = $this->getFieldDefinition($blockTypeField);
 						}
 
 						$blockTypeDefs[$blockType->handle] = array(
@@ -83,6 +71,23 @@ class ArtVandelay_FieldsService extends BaseApplicationComponent
 
 		return $groupDefs;
 	}
+
+    /**
+     * @param FieldModel $field
+     * @return array
+     */
+    private function getFieldDefinition(FieldModel $field)
+    {
+        return array(
+            'name'         => $field->name,
+            'context'      => $field->context,
+			'required'     => $field->required,
+            'instructions' => $field->instructions,
+            'translatable' => $field->translatable,
+            'type'         => $field->type,
+            'settings'     => $field->settings
+        );
+    }
 
 	public function exportTabFields($section, $entryType, $tabName)
 	{
@@ -301,6 +306,7 @@ class ArtVandelay_FieldsService extends BaseApplicationComponent
 							$blockTypeField->required     = $blockTypeFieldDef['required'];
 							$blockTypeField->translatable = $blockTypeFieldDef['translatable'];
 							$blockTypeField->type         = $blockTypeFieldDef['type'];
+							$blockTypeField->settings     = $blockTypeFieldDef['settings'];
 
 							$newBlockTypeFields[] = $blockTypeField;
 						}


### PR DESCRIPTION
There was a problem when exporting and importing fields of matrix blocks.
Settings of these fields were not included in the export, and also not imported.

I have made one function to extract field attributes (including settings) for both types of fields in the fields service. Settings are now also imported for matrix block fields.

In addition there was an issue with data getting lost when importing block types. I've modified the fields service so that imported block types are added to the settings of the matrix field. They are then stored together with the matrix field by the MatrixFieldType onAfterSave function.
