### PR TITLE
Commandline export of fields and sections

### DIFF
--- a/consolecommands/ArtVandelayCommand.php
+++ b/consolecommands/ArtVandelayCommand.php
@@ -24,4 +24,22 @@ class ArtVandelayCommand extends BaseCommand
 			print_r($result->errors);
 		}
 	}
+
+	/**
+	 * Exports the datamodel of craft (fields and sections)
+	 * @param string $file file to write the schema to
+	 */
+	public function actionExport($file = 'craft/config/schema.json')
+	{
+
+		$fieldGroups = craft()->fields->getAllGroups();
+		$sections = craft()->sections->getAllSections();
+
+		$schema = array(
+			'fields' => craft()->artVandelay_fields->export($fieldGroups),
+			'sections' => craft()->artVandelay_sections->export($sections),
+		);
+
+		file_put_contents($file, json_encode($schema, JSON_PRETTY_PRINT, JSON_NUMERIC_CHECK));
+	}
 }

--- a/services/ArtVandelay_SectionsService.php
+++ b/services/ArtVandelay_SectionsService.php
@@ -4,7 +4,12 @@ namespace Craft;
 class ArtVandelay_SectionsService extends BaseApplicationComponent
 {
 
-	public function export(array $sections, $allowedEntryTypeIds)
+	/**
+	 * @param SectionModel[] $sections
+	 * @param null $allowedEntryTypeIds
+	 * @return array
+	 */
+	public function export(array $sections, $allowedEntryTypeIds = null)
 	{
 		$sectionDefs = array();
 


### PR DESCRIPTION
Added a commandline export that generates a schema.json in craft/config.
For now this only includes fields and sections.

Set $allowedEntryTypeIds default to null in sections service export so that all entrytypes are exported by default.
